### PR TITLE
improves speed in checkPermission by replacing client.readStringUntil method with a while loop and client.read()

### DIFF
--- a/AccessPortal.cpp
+++ b/AccessPortal.cpp
@@ -165,14 +165,20 @@ bool AccessPortal::checkPermission(const char* permission, String userToken) {
   client.println();
   client.println(payload);
   Serial.println("request sent");
+  String line; 
+  boolean responseStart = false;
   while (client.connected()) {
-    String line = client.readStringUntil('\n');
-    if (line == "\r") {
-      Serial.println("headers received");
-      break;
+    char c = client.read();
+    if(responseStart == true) {
+      line += c;
+    }
+    if(c == ']') {
+      break; // read string returned by endpoint until terminating ]
+    }
+    if(c == '[') {
+      responseStart = true;
     }
   }
-  String line = client.readStringUntil(']'); // read string returned by endpoint until terminating ]
   Serial.println("reply was:");
   Serial.println("==========");
   Serial.println(line);


### PR DESCRIPTION
Increases speed in checkPermission method by replacing very slow client.readStringUntil method with a while loop reads characters from the endpoint and places them in a string if and only if they lie between the '[' and ']' characters. 